### PR TITLE
Update links to use new org name: amzn->amazon-ion.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ion-hash-test"]
 	path = ion-hash-test
-	url = https://github.com/amzn/ion-hash-test.git
+	url = https://github.com/amazon-ion/ion-hash-test.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/amzn/ion-hash-js/issues), or [recently closed](https://github.com/amzn/ion-hash-js/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
+When filing an issue, please check [existing open](https://github.com/amazon-ion/ion-hash-js/issues), or [recently closed](https://github.com/amazon-ion/ion-hash-js/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -41,7 +41,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amzn/ion-hash-js/labels/help%20wanted) issues is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/amazon-ion/ion-hash-js/labels/help%20wanted) issues is a great place to start.
 
 
 ## Code of Conduct
@@ -56,6 +56,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/amzn/ion-hash-js/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/amazon-ion/ion-hash-js/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Amazon Ion Hash JavaScript
 
-An implementation of [Amazon Ion Hash](http://amzn.github.io/ion-hash) in JavaScript.
+An implementation of [Amazon Ion Hash](https://amazon-ion.github.io/ion-hash) in JavaScript.
 
 [![Build Status](https://travis-ci.org/amzn/ion-hash-js.svg?branch=master)](https://travis-ci.org/amzn/ion-hash-js)
 [![npm version](https://img.shields.io/npm/v/ion-hash-js.svg)](https://www.npmjs.com/package/ion-hash-js)
-[![license](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amzn/ion-hash-js/blob/master/LICENSE)
-[![docs](https://img.shields.io/badge/docs-api-green.svg?style=flat-square)](https://amzn.github.io/ion-hash-js/api)
+[![license](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amazon-ion/ion-hash-js/blob/master/LICENSE)
+[![docs](https://img.shields.io/badge/docs-api-green.svg?style=flat-square)](https://amazon-ion.github.io/ion-hash-js/api)
 
 ## Getting Started
 
@@ -99,7 +99,7 @@ The easiest way to clone the `ion-hash-js` repository and initialize its `ion-ha
 submodule is to run the following command:
 
 ```
-$ git clone --recursive https://github.com/amzn/ion-hash-js.git ion-hash-js
+$ git clone --recursive https://github.com/amazon-ion/ion-hash-js.git ion-hash-js
 ```
 
 Alternatively, the submodule may be initialized independently from the clone
@@ -113,7 +113,7 @@ $ git submodule update
 
 ## Known Issues
 
-Any tests commented out in [tests/ion_hash_tests.ion](https://github.com/amzn/ion-hash-js/blob/master/tests/ion_hash_tests.ion)
+Any tests commented out in [tests/ion_hash_tests.ion](https://github.com/amazon-ion/ion-hash-js/blob/master/tests/ion_hash_tests.ion)
 are not expected to work at this time.
 
 

--- a/package.json
+++ b/package.json
@@ -10,18 +10,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/amzn/ion-hash-js.git"
+    "url": "https://github.com/amazon-ion/ion-hash-js.git"
   },
   "keywords": [
     "ion",
     "hash"
   ],
-  "author": "The Ion Team <ion-team@amazon.com> (https://amzn.github.io/ion-docs/)",
+  "author": "The Ion Team <ion-team@amazon.com> (https://amazon-ion.github.io/ion-docs/)",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/amzn/ion-hash-js/issues"
+    "url": "https://github.com/amazon-ion/ion-hash-js/issues"
   },
-  "homepage": "https://github.com/amzn/ion-hash-js#readme",
+  "homepage": "https://github.com/amazon-ion/ion-hash-js#readme",
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",

--- a/src/IonHash.ts
+++ b/src/IonHash.ts
@@ -43,7 +43,7 @@ export function makeHashWriter(writer: Writer,
 /**
  * Reader decorator that computes the Ion hash of values read.
  *
- * @see [Reader](https://amzn.github.io/ion-js/api/interfaces/_ionreader_.reader.html)
+ * @see [Reader](https://amazon-ion.github.io/ion-js/api/interfaces/_ionreader_.reader.html)
  * @noInheritDoc
  */
 export interface HashReader extends Reader {
@@ -64,7 +64,7 @@ export interface HashReader extends Reader {
 /**
  * Writer decorator that computes the Ion hash of written values.
  *
- * @see [Writer](https://amzn.github.io/ion-js/api/interfaces/_ionwriter_.writer.html)
+ * @see [Writer](https://amazon-ion.github.io/ion-js/api/interfaces/_ionwriter_.writer.html)
  * @noInheritDoc
  */
 export interface HashWriter extends Writer {


### PR DESCRIPTION
Signed-off-by: Linlin Sun <linls@amazon.com>

*Issue #, if available:*
N/A
*Description of changes:*
This PR updated the urls to use new org name: amzn --> amazon-ion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
